### PR TITLE
Store flightplan to device

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "3.0.5", features = ["derive"] }
 csv = "1.1.6"
 google_maps = { version = "2.1.4", features = ["elevation", "enable-reqwest", "rustls", "brotli"], default-features = false }
 kml = "0.4.0"
+libmtp-rs = "0.7.7"
 regex = "1.5.4"
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.73"

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ pub enum Error {
     InputOutput(std::io::Error),
     KmlParsingFailed(kml::Error),
     CsvParsingFailed(csv::Error),
+    MtpFailure(crate::mtp::MtpError),
     MalformedLitchiMission(&'static str),
     AltitudeOverflow(std::num::IntErrorKind),
     MissingTitle,
@@ -28,5 +29,11 @@ impl From<csv::Error> for Error {
 impl From<std::io::Error> for Error {
     fn from(underlying: std::io::Error) -> Self {
         Error::InputOutput(underlying)
+    }
+}
+
+impl From<crate::mtp::MtpError> for Error {
+    fn from(underlying: crate::mtp::MtpError) -> Self {
+        Error::MtpFailure(underlying)
     }
 }

--- a/src/flightplan/from_csv.rs
+++ b/src/flightplan/from_csv.rs
@@ -11,11 +11,11 @@ use crate::litchi::csv::de::Altitude;
 type PoiKey = (u64, u64);
 
 
-impl<'a, 'f> TryFrom<&'f [MissionRecord]> for FlightPlan<'f> {
+impl<'a, 'f> TryFrom<&'a [MissionRecord]> for FlightPlan<'f> {
 
     type Error = Error;
     
-    fn try_from(records: &'f [MissionRecord]) -> Result<Self, Self::Error> {
+    fn try_from(records: &'a [MissionRecord]) -> Result<Self, Self::Error> {
 
         let poi: HashSet<_> = records
             .iter()

--- a/src/flightplan/from_kml.rs
+++ b/src/flightplan/from_kml.rs
@@ -9,10 +9,10 @@ use crate::{flightplan::model::Waypoint, litchi::kml::Mission};
 pub use super::model::FlightPlan;
 use super::Action;
 
-impl<'a, 'm, 'f> TryFrom<&'f Mission<'m>> for FlightPlan<'f> {
+impl<'m, 'f> TryFrom<&'_ Mission<'m>> for FlightPlan<'f> {
     type Error = crate::error::Error;
 
-    fn try_from(mission: &'f Mission) -> std::result::Result<Self, Self::Error> {
+    fn try_from(mission: &'_ Mission) -> std::result::Result<Self, Self::Error> {
         let mut poi = vec![];
 
         let waypoints: Result<Vec<_>> =
@@ -39,7 +39,7 @@ impl<'a, 'm, 'f> TryFrom<&'f Mission<'m>> for FlightPlan<'f> {
     }
 }
 
-impl<'a, 'w> TryFrom<&'a Coord> for Waypoint {
+impl<'a> TryFrom<&'a Coord> for Waypoint {
     type Error = crate::error::Error;
 
     fn try_from(coord: &'a Coord) -> std::result::Result<Self, Self::Error> {

--- a/src/flightplan/model.rs
+++ b/src/flightplan/model.rs
@@ -3,13 +3,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct FlightPlan<'f> {
     pub version: u8,
-    pub title: &'f str,
+    pub title: String,
     pub product: &'f str,
 
     #[serde(rename = "productId")]
     pub product_id: u16,
 
-    pub uuid: &'f str,
+    pub uuid: String,
     pub date: u64,
 
     pub progressive_course_activated: bool,

--- a/src/mtp.rs
+++ b/src/mtp.rs
@@ -1,8 +1,9 @@
-use std::{str::FromStr, num::ParseIntError};
+use std::str::FromStr;
 
-use libmtp_rs::{device::{raw::RawDevice, StorageSort, MtpDevice}, storage::{Parent, files::File}, internals::DeviceEntry, object::Object};
+use chrono::TimeZone;
+use libmtp_rs::{device::{raw::RawDevice, StorageSort, MtpDevice}, storage::{Parent, files::{File, FileMetadata}}, internals::DeviceEntry, object::{Object, filetypes::Filetype}, util::HandlerReturn};
 
-use crate::error::Error;
+use crate::{error::Error, flightplan::FlightPlan};
 
 #[derive(Debug)]
 pub enum MtpError {
@@ -10,7 +11,8 @@ pub enum MtpError {
     NoMtpDeviceDetected,
     MalformedDeviceId,
     UnableToOpenDevice,
-    NoFreeFlight6Folder
+    NoFreeFlight6Folder,
+    NoStorage
 }
 
 impl From<libmtp_rs::error::Error> for MtpError {
@@ -71,13 +73,14 @@ fn find_raw_device(device_id: Option<&str>) -> Result<RawDevice, MtpError> {
 }
 
 
-fn find_freeflight6<'a, 'f>(files: &'f [File<'a>]) -> Option<&'f File<'a>> {
+fn find_folder_by_name<'a, 'f>(name: &'_ str, files: &'f [File<'a>]) -> Option<&'f File<'a>>  {
 
     for file in files {
-        if file.name() == "FreeFlight 6" {
+        if file.name() == name {
             return Some(file);
         }
     }
+
     None
 }
 
@@ -85,26 +88,100 @@ pub fn find_device(device: Option<&str>) -> Result<MtpDevice, Error> {
 
     find_raw_device(device)?
         .open_uncached()
-        .ok_or(Error::from(MtpError::UnableToOpenDevice))
+        .ok_or_else(|| Error::from(MtpError::UnableToOpenDevice))
 }
 
-pub fn find_freeflight6_folder(device: &mut MtpDevice) -> Result<u32, Error> {
+pub fn find_some_folder(device: &mut MtpDevice, parent: Parent, name: &str) -> Result<Option<u32>, Error> {
 
     device.update_storage(StorageSort::NotSorted).map_err(MtpError::InternalFailure)?;
 
     if let Some((_, storage)) = device.storage_pool().iter().next() {
 
-        let root = storage.files_and_folders(Parent::Root);
+        let root = storage.files_and_folders(parent);
 
-        let freeflight6_folder = find_freeflight6(root.as_slice())
-            .ok_or(MtpError::NoFreeFlight6Folder)?;
+        let folder = find_folder_by_name(name, root.as_slice()).map(File::id);
 
-        return Ok(freeflight6_folder.id())
+        return Ok(folder)
     }
 
-    Err(Error::from(MtpError::NoFreeFlight6Folder))
+    Ok(None)
 }
 
-pub fn store_flightplan() {
-    
+
+pub fn find_freeflight6_folder(device: &mut MtpDevice) -> Result<u32, Error> {
+
+    find_some_folder(device, Parent::Root, "FreeFlight 6" )?
+        .ok_or_else(|| Error::from(MtpError::NoFreeFlight6Folder))
 }
+
+fn find_flightplan_folder(device: &mut MtpDevice, ff6_folder_id: u32) -> Result<Option<u32>, Error> {
+
+    find_some_folder(device, Parent::Folder(ff6_folder_id), "flightPlan" )
+}
+
+fn create_folder(device: &mut MtpDevice, parent: Parent, name: &str) -> Result<u32, Error> {
+
+    device.update_storage(StorageSort::NotSorted).map_err(MtpError::InternalFailure)?;
+
+    let pool = device.storage_pool();
+
+    let (_, storage)= pool.iter().next()
+        .ok_or(MtpError::NoStorage)?;
+
+    let (folder_id, _) = storage.create_folder(name, parent).map_err(MtpError::InternalFailure)?;
+
+    Ok(folder_id)
+
+}
+
+pub fn store_flightplan(device: &mut MtpDevice, flightplan: &FlightPlan) -> Result<(), Error> {
+
+    let ff6_folder_id = find_freeflight6_folder(device)?;
+
+    let fp_folder_id = match find_flightplan_folder(device, ff6_folder_id)? {
+        Some(id) => id,
+        None => create_folder(device, Parent::Folder(ff6_folder_id), "flightPlan")?
+    };
+
+    let dest = create_folder(device, Parent::Folder(fp_folder_id), &flightplan.uuid)?;
+
+    store_flightplan_at(device, dest, flightplan)
+}
+
+pub fn store_flightplan_at(device: &mut MtpDevice, dest_folder_id: u32, flightplan: &FlightPlan) -> Result<(), Error>  {
+
+    let modification_date = chrono::Utc.timestamp_millis(flightplan.date as i64);
+
+    let mut buffer: Vec<u8> = flightplan.into();
+
+    let metadata = FileMetadata {
+        file_size: buffer.len() as u64,
+        file_name: "savedPlan.json",
+        file_type: Filetype::Text,
+        modification_date
+    };
+
+    let handler = |mut data: &mut [u8]| {
+
+        use std::io::Write;
+
+        match data.write(buffer.as_slice()) {
+
+            Ok(n) => {
+
+                buffer.drain(0..n);
+
+                HandlerReturn::Ok(n as u32)
+            },
+            Err(_) => HandlerReturn::Error,
+        }
+    };
+
+    let pool = device.storage_pool();
+
+    pool.send_file_from_handler(handler, Parent::Folder(dest_folder_id), metadata)
+        .map_err(MtpError::InternalFailure)
+        .map_err(Error::from)
+        .and(Ok(()))
+}
+

--- a/src/mtp.rs
+++ b/src/mtp.rs
@@ -1,0 +1,110 @@
+use std::{str::FromStr, num::ParseIntError};
+
+use libmtp_rs::{device::{raw::RawDevice, StorageSort, MtpDevice}, storage::{Parent, files::File}, internals::DeviceEntry, object::Object};
+
+use crate::error::Error;
+
+#[derive(Debug)]
+pub enum MtpError {
+    InternalFailure(libmtp_rs::error::Error),
+    NoMtpDeviceDetected,
+    MalformedDeviceId,
+    UnableToOpenDevice,
+    NoFreeFlight6Folder
+}
+
+impl From<libmtp_rs::error::Error> for MtpError {
+    fn from(underlying: libmtp_rs::error::Error) -> Self {
+        MtpError::InternalFailure(underlying)
+    }
+}
+
+struct DeviceId(u16, u16);
+
+impl FromStr for DeviceId {
+    type Err = MtpError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+
+        if let Some((vendor, product)) = s.split_once(':') {
+
+            return match (u16::from_str(vendor), u16::from_str(product)) {
+                
+                (Ok(v), Ok(p)) => Ok(DeviceId(v, p)),
+
+                _ => Err(MtpError::MalformedDeviceId)
+            }
+        }
+
+        Err(MtpError::MalformedDeviceId) 
+    }
+
+
+}
+
+
+fn find_raw_device(device_id: Option<&str>) -> Result<RawDevice, MtpError> {
+
+    let mut devices = libmtp_rs::device::raw::detect_raw_devices()?.into_iter();
+
+    let device_id = device_id.map(DeviceId::from_str).transpose()?;
+
+    match device_id {
+
+        Some(DeviceId(vendor, product)) => {
+
+            for device in devices {
+
+                let DeviceEntry { vendor_id, product_id, ..} = device.device_entry();
+
+                if vendor_id == vendor && product_id == product {
+
+                    return Ok(device)
+                }
+            }
+
+            Err(MtpError::NoMtpDeviceDetected)
+        },
+
+        None => devices.next().ok_or(MtpError::NoMtpDeviceDetected),
+    }
+}
+
+
+fn find_freeflight6<'a, 'f>(files: &'f [File<'a>]) -> Option<&'f File<'a>> {
+
+    for file in files {
+        if file.name() == "FreeFlight 6" {
+            return Some(file);
+        }
+    }
+    None
+}
+
+pub fn find_device(device: Option<&str>) -> Result<MtpDevice, Error> {
+
+    find_raw_device(device)?
+        .open_uncached()
+        .ok_or(Error::from(MtpError::UnableToOpenDevice))
+}
+
+pub fn find_freeflight6_folder(device: &mut MtpDevice) -> Result<u32, Error> {
+
+    device.update_storage(StorageSort::NotSorted).map_err(MtpError::InternalFailure)?;
+
+    if let Some((_, storage)) = device.storage_pool().iter().next() {
+
+        let root = storage.files_and_folders(Parent::Root);
+
+        let freeflight6_folder = find_freeflight6(root.as_slice())
+            .ok_or(MtpError::NoFreeFlight6Folder)?;
+
+        return Ok(freeflight6_folder.id())
+    }
+
+    Err(Error::from(MtpError::NoFreeFlight6Folder))
+}
+
+pub fn store_flightplan() {
+    
+}


### PR DESCRIPTION
Using MTP we're able to store the generated flightplan directly to the device used to pilot : no need to copy/paste the JSON file into internal memory by hand !